### PR TITLE
fix: :bug: fixed bug on Testimonial factory

### DIFF
--- a/database/factories/TestimonialsFactory.php
+++ b/database/factories/TestimonialsFactory.php
@@ -10,7 +10,7 @@ $factory->define(Testimonial::class, function (Faker $faker) {
         'user_id' => 2,
         'name' => $faker->name,
         'company' => $faker->company,
-        'title' => $faker->text,
+        'title' => $faker->text($maxNbChars = 200),
         'description' => $faker->text,
     ];
 });


### PR DESCRIPTION
Sometimes the factory generates text longer than 255 chars, and the field on can store 255 chars due the field definition. So I fixed the factory to create text with max 200 chars